### PR TITLE
fix direct access to config

### DIFF
--- a/jobs/base.py
+++ b/jobs/base.py
@@ -16,13 +16,13 @@ class Step(ABC):
         self.config = config
         self.logger = logger
 
-        self.config_dataset = config.get_dataset()
-        self.config_training = config.get_training()
-        self.config_model = config.get_model()
+        self.config_dataset = self.config.get_dataset()
+        self.config_training = self.config.get_training()
+        self.config_model = self.config.get_model()
 
-        self.encoder_name = config.get_encoder_name()
+        self.encoder_name = self.config.get_encoder_name()
 
-        self.device = torch.device(self.get_config().get("device", "cuda") \
+        self.device = torch.device(self.config.get_config().get("device", "cuda") \
                                     if torch.cuda.is_available() else "cpu")
 
     def define_transform(self):

--- a/jobs/base.py
+++ b/jobs/base.py
@@ -22,7 +22,7 @@ class Step(ABC):
 
         self.encoder_name = config.get_encoder_name()
 
-        self.device = torch.device(self.config.get("device", "cuda") \
+        self.device = torch.device(self.get_config().get("device", "cuda") \
                                     if torch.cuda.is_available() else "cpu")
 
     def define_transform(self):


### PR DESCRIPTION
## Summary by Sourcery

Fix direct access to configuration by using self.config instead of config and updating device configuration retrieval

Bug Fixes:
- Corrected configuration access by using self.config method calls instead of directly passing the config object

Enhancements:
- Updated device configuration retrieval to use a more explicit method of getting configuration parameters